### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1">
   <name>Silk workbench</name>
   <description>NURBS Surface modeling tools focused on low degree and seam continuity</description>
-  <version></version>
-  <date></date>
+  <version>1.0.0</version>
+  <date>2022-05-27</date>
   <maintainer email="@edwardvmills">edwardvmills</maintainer>
   <license file="LICENSE">GPL-3</license>
   <url type="repository" branch="master">https://github.com/edwardvmills/Silk</url>
@@ -14,9 +14,8 @@
   <content>
     <workbench>
       <name>Silk workbench</name>
-      <classname>SilkWorkbench</classname>
+      <classname>Silk</classname>
       <description>NURBS Surface modeling tools focused on low degree and seam continuity</description>
-      <version></version>
       <subdirectory>./</subdirectory>
       <icon>Resources/Icons/Silk.svg</icon>
       <freecadmin>0.18.0</freecadmin>


### PR DESCRIPTION
Version information can't be left blank, or the ZIP version of the updater will never find updated versions. Also, the classname wasn't quite right in the initial version of the file, this corrects that.